### PR TITLE
Fixed typo that breaks the Seq GAN

### DIFF
--- a/MLE_SeqGAN/sequence_gan.py
+++ b/MLE_SeqGAN/sequence_gan.py
@@ -150,7 +150,7 @@ def main():
     # config.gpu_options.per_process_gpu_memory_fraction = 0.5
     config.gpu_options.allow_growth = True
     sess = tf.Session(config=config)
-    sess.run(tf.global_variables_initializer)
+    sess.run(tf.global_variables_initializer())
 
     generate_samples(sess, target_lstm, 64, 10000, positive_file)
     gen_data_loader.create_batches(positive_file)


### PR DESCRIPTION
Change 
sess.run(tf.global_variables_initializer)
to 
sess.run(tf.global_variables_initializer()) 
since it is a function.